### PR TITLE
Update continuous-integration.yml to test PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,8 @@ on:
 
 jobs:
   ci:
-    uses: ray-di/.github/.github/workflows/continuous-integration.yml@next_stable
+    uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.4", "8.0"]'
-      current_stable: 8.1
-      next_stable: 8.2
+      old_stable: '["7.4", "8.0", "8.1", "8.2"]'
+      current_stable: 8.3
       script: demo/run.php

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <2022> <Akihito Koriyama>
+Copyright (c) <2022-2024> <Akihito Koriyama>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changes were made to the .github/workflows/continuous-integration.yml to use v1 instead of next_stable. old_stable and current_stable values were also updated. These changes aim to keep our CI workflow consistent with the latest stable releases.