### PR TITLE
Enable PHP 8.4 compat

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,4 +9,4 @@ jobs:
   cs:
     uses: ray-di/.github/.github/workflows/coding-standards.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,6 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.4", "8.0", "8.1", "8.2"]'
-      current_stable: 8.3
+      old_stable: '["7.4", "8.0", "8.1", "8.2", "8.3"]'
+      current_stable: 8.4
       script: demo/run.php

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,4 +9,4 @@ jobs:
   sa:
     uses: ray-di/.github/.github/workflows/static-analysis.yml@v1
     with:
-      php_version: 8.1
+      php_version: 8.3


### PR DESCRIPTION
Updated `php_version` to 8.3 in coding standards and static analysis workflows. Added 8.3 to `old_stable` and set `current_stable` to 8.4 in the continuous integration workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated PHP version in coding standards and static analysis workflows to ensure compatibility with newer standards.
	- Expanded support for continuous integration to include PHP version 8.3.

- **Bug Fixes**
	- Incremented the current stable PHP version in the continuous integration workflow from 8.3 to 8.4 for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->