### PR TITLE
Add Internal Environment Variable Registry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # https://php.watch/articles/composer-gitattributes
+* text=auto eol=lf
 
 # Exclude build/test files from archive
 /tests            export-ignore

--- a/src/EnvJson.php
+++ b/src/EnvJson.php
@@ -111,28 +111,8 @@ final class EnvJson
         }
     }
 
-    /**
-     * Creates an object with all environment variables tracked by this library
-     */
-    private function getRegistryAsObject(): stdClass
-    {
-        $data = new stdClass();
-        foreach (self::$envRegistry as $key => $val) {
-            $data->{$key} = $val;
-        }
-
-        return $data;
-    }
-
-    /** @return array<string, string> */
-    public function getAllEnv(): array
-    {
-        return self::$envRegistry;
-    }
-
     private function isValidEnv(stdClass $schema, Validator $validator): bool
     {
-        // Option 1: Continue using Env class but with added fallback
         $env = ($this->envFactory)($schema);
 
         // Check if environment variables are missing and add from registry
@@ -141,9 +121,6 @@ final class EnvJson
                 $env->{$key} = $val;
             }
         }
-
-        // Alternatively, use Option 2: Use only registry for validation
-        // $env = $this->getRegistryAsObject();
 
         $validator->validate($env, $schema);
 

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -6,13 +6,15 @@ namespace Koriym\EnvJson;
 
 use PHPUnit\Framework\TestCase;
 
+use function str_replace;
+
 class JsonTest extends TestCase
 {
     public function testJson(): void
     {
         $envFile = __DIR__ . '/Fake/.env';
         $json = new Json($envFile);
-        $this->assertJsonStringEqualsJsonString('{
+        $this->assertSameNormalized('{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [
@@ -41,5 +43,11 @@ class JsonTest extends TestCase
     "API": "http://example.com"
 }
 ', $json->data);
+    }
+
+    private function assertSameNormalized(string $expected, string $actual, string $message = '')
+    {
+        $normalize = static fn ($s) => str_replace(["\r\n", "\r"], "\n", $s);
+        $this->assertSame($normalize($expected), $normalize($actual), $message);
     }
 }

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -36,7 +36,7 @@ class JsonTest extends TestCase
     }
 }
 ', $json->schema);
-        $this->assertSame('{
+        $this->assertSameNormalized('{
     "$schema": "./env.schema.json",
     "FOO": "foo1",
     "BAR": "bar1",

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -45,7 +45,7 @@ class JsonTest extends TestCase
 ', $json->data);
     }
 
-    private function assertSameNormalized(string $expected, string $actual, string $message = '')
+    private function assertSameNormalized(string $expected, string $actual, string $message = ''): void
     {
         $normalize = static fn ($s) => str_replace(["\r\n", "\r"], "\n", $s);
         $this->assertSame($normalize($expected), $normalize($actual), $message);

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -12,7 +12,7 @@ class JsonTest extends TestCase
     {
         $envFile = __DIR__ . '/Fake/.env';
         $json = new Json($envFile);
-        $this->assertSame('{
+        $this->assertJsonStringEqualsJsonString('{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
     "required": [


### PR DESCRIPTION
This PR addresses an issue with environment variable handling in PHP that can cause inconsistent behavior when retrieving all environment variables.

### Problem

When using `getenv()` without arguments to retrieve all environment variables, the function may not reliably return all variables that were set using `putenv()`. This is especially problematic when variables are set by PHP-FPM or the web server. Even `getenv(null, true)` in PHP 7.1+ doesn't always capture all variables.

This inconsistency can lead to validation problems in our library when verifying environment variables against a schema.

### Solution

This PR implements an internal registry to track all environment variables set by the library:

1. Added a static `$envRegistry` array to track environment variables
2. Modified `putEnv()` to record variables in the registry
3. Enhanced `isValidEnv()` to include variables from the registry
4. Added helper methods to access the registry data

### Benefits

- Ensures all environment variables set by the library are tracked consistently
- Makes validation more reliable by including all known environment variables
- Provides a public method to access all environment variables
- Avoids thread-safety issues with `getenv(null)`
- Works consistently across different PHP configurations and SAPIs

### Implementation Notes

- The implementation maintains compatibility with existing code
- The registry only tracks variables explicitly set by the library
- `getenv($key)` for individual variables still works as before
- Added detailed code documentation

### Related Resources

For more information on PHP environment variable handling inconsistencies, see:
https://mattallan.me/posts/how-php-environment-variables-actually-work/

## Sourceryによる概要

PHPにおける環境変数の処理と検証を改善するために、内部環境変数レジストリを実装

新機能:
- ライブラリによって設定された環境変数を追跡するための静的レジストリを追加
- 追跡されたすべての環境変数を取得するための公開メソッドを導入

バグ修正:
- getenv()とputenv()を使用した環境変数の取得の不一致を解決
- 検証中に欠落している環境変数の問題を解決

強化:
- ライブラリによって設定されたすべての変数がキャプチャされることを保証することで、環境変数の検証を改善
- 異なるPHP構成間での環境変数取得の一貫性を強化

テスト:
- JSON比較のために行末を正規化する新しいアサーションメソッドを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement an internal environment variable registry to improve environment variable handling and validation in PHP

New Features:
- Add a static registry to track environment variables set by the library
- Introduce a public method to retrieve all tracked environment variables

Bug Fixes:
- Address inconsistent environment variable retrieval using getenv() and putenv()
- Resolve issues with missing environment variables during validation

Enhancements:
- Improve environment variable validation by ensuring all library-set variables are captured
- Enhance environment variable retrieval consistency across different PHP configurations

Tests:
- Add a new assertion method to normalize line endings for JSON comparisons

</details>